### PR TITLE
Remove hardcoding of page when closing dialog

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,7 +108,7 @@ class $modify(GarageButSupporter, GJGarageLayer) {
 			auto icon = GJItemIcon::createBrowserItem(UnlockType::Cube, 71);
 			cur->createUnlockObject(icon, winSize / 2, 0.5f);
 
-			self->setupPage(1, IconType::Cube);
+			self->selectTab(IconType::Cube);
         }
 	};
 


### PR DESCRIPTION
Some mods, like the one I am making right now, do not assume that the Meltdown supporter icon is on page 1. Just selecting the tab and letting it refresh the current page has the same effect.